### PR TITLE
Bump minimum Python version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,11 @@ jobs:
   test:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13' 
 
       - name: Install the app
         run: pipx install .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,8 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.13' 
+          python-version: '3.13'
+          cache: poetry
 
       - name: Install the app
         run: pipx install .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,9 @@ jobs:
           cache: poetry
 
       - name: Install the app
-        run: pipx install .
+        run: |
+          pipx install poetry --python $(which python)
+          pipx install .
 
       - name: Test
         shell: cmd

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A lot of Windows apps will create shortcuts on the desktop without asking the us
 
 # Requirements
 * Windows 10 or newer (anything newer than Windows Vista probably works, but not supported)
-* Python ^3.9
+* Python 3.10 or newer
 
 # Installation
 Using [pipx](https://github.com/pypa/pipx):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.9"
+python = "^3.10"
 
 [tool.poetry.scripts]
 scleaner = "cleaner:main"


### PR DESCRIPTION
As per upcoming 3.9 deprecation: https://devguide.python.org/versions/