### PR TITLE
Drop support for Python 3.9 and Windows 10

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -46,7 +46,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
   test:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: Install the app
         run: pipx install .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.14'
+
       - name: Install the app
         run: pipx install .
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,11 @@ jobs:
           python-version: '3.14'
 
       - name: Install the app
-        run: pipx install .
+        run: |
+          python3 --version
+          python3 -m pip install -U pip
+          python3 -m pip install -U pipx
+          python3 -m pipx install .
 
       - name: Test
         shell: cmd

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ Python 3 script for Windows that removes all shortcuts from the user's Desktop f
 A lot of Windows apps will create shortcuts on the desktop without asking the user for permission. Scheduling this script can help with keeping the desktop clean automatically.
 
 # Requirements
-* Windows 10 or newer (anything newer than Windows Vista probably works, but not supported)
-* Python ^3.9
+* Windows 11 or newer (anything newer than Windows Vista probably works, but support for end-of-support Windows versions is not maintained)
+* Python 3.10 or newer
 
 # Installation
 Using [pipx](https://github.com/pypa/pipx):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "scleaner"
-version = "0.3.0"
-description = ""
+version = "1.0.0"
+description = "Removes all shortcuts from the user's Desktop folder, with optional exceptions."
 authors = ["Rain <Rainyan@users.noreply.github.com>"]
 license = "MIT"
 readme = "README.md"
@@ -11,7 +11,7 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.9"
+python = "^3.10"
 
 [tool.poetry.scripts]
 scleaner = "cleaner:main"


### PR DESCRIPTION
Python 3.9 has reached [end of life on 2025-10-31](https://devguide.python.org/versions/).

Windows 10 support [has ended on October 14, 2025](https://support.microsoft.com/en-us/windows/windows-10-support-has-ended-on-october-14-2025-2ca8b313-1946-43d3-b55c-2b95b107f281).

Therefore, dropping official support for these versions and older. That being said, the app should still keep working on older Windows versions just fine for anything more modern than Vista.